### PR TITLE
fix: handle extra details in destination lookup

### DIFF
--- a/src/lib/geoUtils.ts
+++ b/src/lib/geoUtils.ts
@@ -35,10 +35,20 @@ function toRadians(degrees: number): number {
 }
 
 /**
- * Extract approximate coordinates from destination string
+ * Extract approximate coordinates from a destination string
+ * Handles destinations that include additional details like
+ * regions or countries (e.g. "Roma, Italia" or "Roma (Lazio)").
  */
 export function getApproximateCoordinates(destination: string): { lat: number; lng: number } | null {
-  return getLocationCoordinates(destination);
+  // Remove any additional location details after a comma, opening
+  // parenthesis or a dash surrounded by spaces (" - ") to improve
+  // lookup reliability.
+  const primaryLocation = destination
+    .split(/[,(]/)[0]      // remove text after comma or (
+    .split(' - ')[0]       // handle patterns like "City - Region"
+    .trim();
+
+  return getLocationCoordinates(primaryLocation);
 }
 
 /**

--- a/src/tests/geoUtils.test.ts
+++ b/src/tests/geoUtils.test.ts
@@ -50,6 +50,17 @@ describe('GeoUtils', () => {
       const romaUpper = getApproximateCoordinates('ROMA');
       expect(romaLower).toEqual(romaUpper);
     });
+
+    it('should handle destinations with extra details', () => {
+      const withCountry = getApproximateCoordinates('Roma, Italia');
+      expect(withCountry).toEqual({ lat: 41.9028, lng: 12.4964 });
+
+      const withRegion = getApproximateCoordinates('Roma (Lazio)');
+      expect(withRegion).toEqual({ lat: 41.9028, lng: 12.4964 });
+
+      const withDash = getApproximateCoordinates('Roma - Lazio');
+      expect(withDash).toEqual({ lat: 41.9028, lng: 12.4964 });
+    });
   });
 
   describe('calculateTripDistance', () => {


### PR DESCRIPTION
## Summary
- robustly parse destination strings with extra region or country info
- add tests for city names containing commas, parentheses or dashes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891fcc109a8832e860b3ca7497987bf